### PR TITLE
faster ci builds through a pre-built image

### DIFF
--- a/infrastructure/travis/Dockerfile
+++ b/infrastructure/travis/Dockerfile
@@ -1,18 +1,3 @@
-FROM ubuntu:18.04
+FROM spirulence/frc2019-ci:release-2019.2.1
 
-ENV WPILIB_VERSION=2019.2.1
-
-RUN apt-get update -q && apt-get install -qy wget
-
-RUN wget -q https://github.com/wpilibsuite/allwpilib/releases/download/v$WPILIB_VERSION/WPILib_Linux-$WPILIB_VERSION.tar.gz \
-    && mkdir -p /root/frc2019/ && tar -xzf WPILib_Linux-$WPILIB_VERSION.tar.gz -C /root/frc2019/ \
-    && rm WPILib_Linux-$WPILIB_VERSION.tar.gz
-
-ADD . /app
-
-ENV JAVA_HOME=/root/frc2019/jdk
-
-WORKDIR /app
-
-RUN PATH=$JAVA_HOME/bin:$PATH ./gradlew buildEnvironment
-
+ADD . /robot

--- a/infrastructure/travis/docker-compose.yml
+++ b/infrastructure/travis/docker-compose.yml
@@ -5,4 +5,3 @@ services:
     build:
       context: ../../
       dockerfile: infrastructure/travis/Dockerfile
-    command: ./gradlew test


### PR DESCRIPTION
I've put together a Docker image that contains the FRC environment - this should reduce our build times in Travis substantially. We're at about 5 minutes now.