### PR TITLE
use smaller pre-built docker image in CI

### DIFF
--- a/infrastructure/travis/Dockerfile
+++ b/infrastructure/travis/Dockerfile
@@ -1,3 +1,3 @@
-FROM spirulence/frc2019-ci:release-2019.2.1
+FROM spirulence/frc2019-ci:latest
 
 ADD . /robot


### PR DESCRIPTION
This PR migrates CI to an even smaller and faster pre-built image that contains just what's needed for CI and nothing more.